### PR TITLE
add prefs button & show more prices by default

### DIFF
--- a/krypto@sereneblue/extension.js
+++ b/krypto@sereneblue/extension.js
@@ -87,8 +87,19 @@ const krypto = GObject.registerClass({ GTypeName: 'krypto'},
                 styleClass: 'calculator-input'
             });
 
+	    this._prefs_button = new St.Button({
+		style_class: 'button prefs-button'
+            });
+	    this._prefs_button.child = new St.Icon({
+		icon_name: 'preferences-system-symbolic'
+            });
+
             this._distraction_mode_switch.connect('activate', this._enableDistractionFreeMode.bind(this));
             this._calculator_input.clutter_text.connect('key-release-event', this._calculatePrice.bind(this));
+            this._prefs_button.connect('clicked', () => {
+		this.menu._getTopMenu().close();
+		ExtensionUtils.openPrefs();
+            });
 
             // add the st widgets to menu items
             // price calculator separator
@@ -99,6 +110,7 @@ const krypto = GObject.registerClass({ GTypeName: 'krypto'},
             this._calculated_crypto.actor.add_child(this._crypto_amount);
             this._calculator_fiat.actor.add_child(this._calculated_price);
             this._calculator_area.actor.add_child(this._calculator_input);
+	    this._calculator_area.actor.add_child(this._prefs_button);
 
             this.menu.addMenuItem(this._distraction_mode_switch);
             this.menu.addMenuItem(this._prices_menu);

--- a/krypto@sereneblue/extension.js
+++ b/krypto@sereneblue/extension.js
@@ -118,6 +118,10 @@ const krypto = GObject.registerClass({ GTypeName: 'krypto'},
             this.menu.addMenuItem(this._calculated_crypto);
             this.menu.addMenuItem(this._calculator_fiat);
             this.menu.addMenuItem(this._calculator_area);
+
+	    this.menu.connect('open-state-changed', (menu, open) => {
+		this._prices_menu.setSubmenuShown(open);
+	    });
         }
         _disableDistractionFreeMode() {
             this._distraction_mode_switch.actor.reactive = true;

--- a/krypto@sereneblue/stylesheet.css
+++ b/krypto@sereneblue/stylesheet.css
@@ -5,7 +5,7 @@
 
 .calculator-input {
     font-size: 16px;
-    width: 225px;
+    width: 175px;
 }
 
 .display-text {
@@ -13,4 +13,21 @@
 	font-weight: bold;
 	width: 225px;
 	text-align: center;
+}
+
+.prefs-button {
+    -st-icon-style: symbolic;
+    border: 2px solid transparent;
+    border-radius: 20px;
+    padding: 10px;
+    min-width: 18px;
+    min-height: 18px;
+}
+
+.prefs-button:hover, .prefs-button:focus {
+    border-color: #777;
+}
+
+.prefs-button > StIcon {
+    icon-size: 18px;
 }


### PR DESCRIPTION
Changes to the following:

- add a button at the right of calculator input box to quickly access extension preferences to change settings.
- show ``more prices'' by default when opening the main menu. 

Aims:
- to more conveniently adjust favorite coins or other settings through the prefs button in the menu.
- It can directly show users‘ second favorite coins with just one click.

Both of these two features are tested under GNOME 44. If you are not interested in them, please ignore it. 
Thanks for providing such an extension.

